### PR TITLE
removes react packages from greenkeeper ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,18 +29,7 @@
       "html-webpack-plugin",
       "babel-loader",
       "sass-loader",
-      "postcss-loader",
-      "react",
-      "react-dom",
-      "react-router",
-      "react-hot-loader",
-      "react-datepicker",
-      "react-tabs",
-      "@types/react",
-      "@types/react-dom",
-      "@types/react-router",
-      "@types/react-datepicker",
-      "@types/react-tabs"
+      "postcss-loader"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #118 

### Description of Changes

We updated to react 16 a while ago - this PR removes react and react related packages from
the greenkeeper ignore block so we will be alerted to new versions.

<!-- For the PR reviewer: -->

### PR Review Checklist

* [ ] **Do the changes match the product spec?**
* [ ] **Are there changes in this PR that weren't originally in the product spec?**
* [ ] **Is a feature toggle introduced for this PR? Is it disabled by default?**
* [ ] **Have you tested the changes?**
* [ ] **Is QE review required? If so, has this been reviewed by QE?** (For all new features, review by QE is required. Minor changes which already have passing functional tests may not need a new QE review -- when in doubt, loop in a QE reviewer).
* [ ] **Are there code changes that require new unit tests? If so, are those tests included?** (A separate PR for tests is not appropriate).
* [ ] **Are documentation updates required? If so, does this PR include it?** (Separate documentation PR is generally not appropriate).
* [ ] **Are the added/edited files named appropriately and located correctly in the project directory structure?**

### Warning

Merging to `master` automatically triggers a deploy in production. 
