### PR TITLE
Webpack Bug? Attempt #2

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,16 +36,16 @@ module.exports = {
         }
       },
       {
-        test: /\.scss$/,
+        test: /\.s?css$/,
         use: [
           'style-loader',
-          {
+          info => ({
             loader: 'css-loader',
             options: {
-              modules: true,
+              modules: true, // false if info.realResource is in node_modules
               importLoaders: 2,
             },
-          },
+          }),
           'postcss-loader',
           {
             loader: 'resolve-url-loader',
@@ -65,19 +65,6 @@ module.exports = {
               sourceMapContents: false,
             }
           },
-        ]
-      },
-      {
-        test: /\.css$/, // only used for external styles (toastify). see https://github.com/webpack/webpack/issues/8406
-        use: [
-          'style-loader',
-          {
-            loader: 'css-loader',
-            options: {
-              importLoaders: 1,
-            },
-          },
-          'postcss-loader',
         ]
       },
       {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,6 +42,7 @@ module.exports = {
           info => ({
             loader: 'css-loader',
             options: {
+              ident: 'css-loader',
               modules: true, // false if info.realResource is in node_modules
               importLoaders: 2,
             },


### PR DESCRIPTION
This one adds the `ident` key to the options. See [diff against the webpack-issue-demo branch](https://github.com/poetapp/explorer-web/compare/webpack-issue-demo...webpack-issue-demo-2).

This fails with the same reason, only it uses the ident name we're passing instead.

```
$ npm run build

> explorer-web@1.0.0 build /.../explorer-web
> NODE_ENV=production webpack --mode production

Building with WebPack production
Hash: 30693086074d247886b1
Version: webpack 4.29.4
Time: 8467ms
Built at: 2019-02-19 16:30:16
 7 assets
Entrypoint main = main.30693086074d247886b1.js
 [24] ./src/images/poet-logo.svg 82 bytes {0} [built]
 [25] ./src/images/poet-logo-white.svg 82 bytes {0} [built]
 [26] ./src/images/poet-quill.svg 82 bytes {0} [built]
 [27] ./src/images/anonymous-avatar-sm.jpg 82 bytes {0} [built]
 [28] ./src/images/ipfs.png 82 bytes {0} [built]
 [29] ./src/images/bitcoin.png 82 bytes {0} [built]
[167] (webpack)/buildin/global.js 472 bytes {0} [built]
[170] ./src/index.scss 1.53 KiB {0} [built]
[182] (webpack)/buildin/module.js 497 bytes {0} [built]
[183] ./node_modules/moment/locale sync ^\.\/.*$ 3 KiB {0} [optional] [built]
[185] ./src/index.jsx + 79 modules 111 KiB {0} [built]
      | ./src/index.jsx 284 bytes [built]
      | ./src/providers/SessionProvider.jsx 406 bytes [built]
      | ./src/providers/ApiProvider.jsx 1.31 KiB [built]
      | ./src/hooks/usePersistedState.js 349 bytes [built]
      | ./src/helpers/api.js 1.44 KiB [built]
      | ./src/Images.js 471 bytes [built]
      | ./src/hooks/useFetch.js 454 bytes [built]
      | ./src/hooks/useWork.js 362 bytes [built]
      | ./src/hooks/useLogin.js 993 bytes [built]
      | ./src/hooks/useSignUp.js 999 bytes [built]
      | ./src/hooks/useConfirmMail.js 560 bytes [built]
      | ./src/hooks/useProfile.js 747 bytes [built]
      | ./src/helpers/jwt.js 184 bytes [built]
      | ./src/hooks/useCounterLoop.js 314 bytes [built]
      |     + 66 hidden modules
    + 499 hidden modules

ERROR in ./src/components/organisms/Login.scss
Module not found: Error: Can't find options with ident 'css-loader'
 @ ./src/components/organisms/Login.scss 2:14-264
 @ ./src/components/organisms/Login.jsx
 @ ./src/components/pages/Login.jsx
 @ ./src/components/routes/Login.jsx
 @ ./src/components/Router.jsx
 @ ./src/components/App.jsx
 @ ./src/index.jsx

ERROR in ./src/index.scss
Module not found: Error: Can't find options with ident 'css-loader'
 @ ./src/index.scss 2:14-240
 @ ./src/index.jsx

ERROR in ./src/components/templates/Main.scss
Module not found: Error: Can't find options with ident 'css-loader'
 @ ./src/components/templates/Main.scss 2:14-263
 @ ./src/components/templates/Main.jsx
 @ ./src/components/pages/Home.jsx
 @ ./src/components/Router.jsx
 @ ./src/components/App.jsx
 @ ./src/index.jsx

ERROR in ./src/components/organisms/Home.scss
Module not found: Error: Can't find options with ident 'css-loader'
 @ ./src/components/organisms/Home.scss 2:14-263
 @ ./src/components/organisms/Home.jsx
 @ ./src/components/pages/Home.jsx
 @ ./src/components/Router.jsx
 @ ./src/components/App.jsx
 @ ./src/index.jsx

ERROR in ./src/components/organisms/Works.scss
Module not found: Error: Can't find options with ident 'css-loader'
 @ ./src/components/organisms/Works.scss 2:14-264
 @ ./src/components/organisms/Works.jsx
 @ ./src/components/pages/Works.jsx
 @ ./src/components/routes/Works.jsx
 @ ./src/components/Router.jsx
 @ ./src/components/App.jsx
 @ ./src/index.jsx

ERROR in ./src/components/organisms/Work.scss
Module not found: Error: Can't find options with ident 'css-loader'
 @ ./src/components/organisms/Work.scss 2:14-263
 @ ./src/components/organisms/Work.jsx
 @ ./src/components/pages/Work.jsx
 @ ./src/components/routes/Work.jsx
 @ ./src/components/Router.jsx
 @ ./src/components/App.jsx
 @ ./src/index.jsx

ERROR in ./node_modules/react-toastify/dist/ReactToastify.css
Module not found: Error: Can't find options with ident 'css-loader'
 @ ./node_modules/react-toastify/dist/ReactToastify.css 2:14-207
 @ ./src/index.jsx

ERROR in ./src/components/organisms/Issuer.scss
Module not found: Error: Can't find options with ident 'css-loader'
 @ ./src/components/organisms/Issuer.scss 2:14-265
 @ ./src/components/organisms/Issuer.jsx
 @ ./src/components/pages/Issuer.jsx
 @ ./src/components/routes/Issuer.jsx
 @ ./src/components/Router.jsx
 @ ./src/components/App.jsx
 @ ./src/index.jsx

ERROR in ./src/components/organisms/SignUp.scss
Module not found: Error: Can't find options with ident 'css-loader'
 @ ./src/components/organisms/SignUp.scss 2:14-265
 @ ./src/components/organisms/SignUp.jsx
 @ ./src/components/pages/SignUp.jsx
 @ ./src/components/routes/SignUp.jsx
 @ ./src/components/Router.jsx
 @ ./src/components/App.jsx
 @ ./src/index.jsx

ERROR in ./src/components/organisms/ConfirmEmail.scss
Module not found: Error: Can't find options with ident 'css-loader'
 @ ./src/components/organisms/ConfirmEmail.scss 2:14-271
 @ ./src/components/organisms/ConfirmEmail.jsx
 @ ./src/components/pages/ConfirmMail.jsx
 @ ./src/components/routes/ConfirmMail.jsx
 @ ./src/components/Router.jsx
 @ ./src/components/App.jsx
 @ ./src/index.jsx

ERROR in ./src/components/organisms/Tokens.scss
Module not found: Error: Can't find options with ident 'css-loader'
 @ ./src/components/organisms/Tokens.scss 2:14-265
 @ ./src/components/organisms/Tokens.jsx
 @ ./src/components/pages/Tokens.jsx
 @ ./src/components/routes/Tokens.jsx
 @ ./src/components/Router.jsx
 @ ./src/components/App.jsx
 @ ./src/index.jsx

ERROR in ./src/components/molecules/Works.scss
Module not found: Error: Can't find options with ident 'css-loader'
 @ ./src/components/molecules/Works.scss 2:14-264
 @ ./src/components/molecules/Works.jsx
 @ ./src/components/organisms/Works.jsx
 @ ./src/components/pages/Works.jsx
 @ ./src/components/routes/Works.jsx
 @ ./src/components/Router.jsx
 @ ./src/components/App.jsx
 @ ./src/index.jsx
Child html-webpack-plugin for "index.html":
     1 asset
    Entrypoint undefined = ./index.html
    [0] ./node_modules/html-webpack-plugin/lib/loader.js!./src/index.html 354 bytes {0} [built]
    [2] (webpack)/buildin/global.js 472 bytes {0} [built]
    [3] (webpack)/buildin/module.js 497 bytes {0} [built]
        + 1 hidden module
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! explorer-web@1.0.0 build: `NODE_ENV=production webpack --mode production`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the explorer-web@1.0.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /.../...-debug.log
```

PR against `master` so Netlify triggers a deploy.