### PR TITLE
fix: authenticatedFetch

### DIFF
--- a/src/components/pages/Login.jsx
+++ b/src/components/pages/Login.jsx
@@ -16,7 +16,7 @@ export const Login = () => {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
 
-  const setAccountWithLoginData = ({ token, issuer }) => account => setAccount(account && { ...account, token, issuer })
+  const setAccountWithLoginData = ({ token, issuer }) => account => setAccount(account && { ...account, token, issuer, email })
 
   const onSubmit = async event => {
     event.preventDefault()

--- a/src/helpers/api.js
+++ b/src/helpers/api.js
@@ -25,13 +25,13 @@ export const Api = ({
 }) => {
   const { apiUrl, nodeUrl } = environmentToUrls(environment, network)
 
-  const authenticatedFetch = (requestInfo, requestInit = { headers: {}}) => fetch(requestInfo, {
+  const authenticatedFetch = token !== undefined ? (requestInfo, requestInit = { headers: {}}) => fetch(requestInfo, {
     ...requestInit,
     headers: {
       ...requestInit.headers,
-      ...(requestInit?.headers?.token || token ? {token: requestInit?.headers?.token || token} : {}),
+      token: requestInit?.headers?.token || token,
     }
-  })
+  }) : fetch
 
   const processParsedResponse = ({ url, options }) => ({ status, body, headers }) => {
     if (status === 200) {

--- a/src/helpers/api.js
+++ b/src/helpers/api.js
@@ -29,7 +29,7 @@ export const Api = ({
     ...requestInit,
     headers: {
       ...requestInit.headers,
-      token: requestInit?.headers?.token || token,
+      ...(requestInit?.headers?.token || token ? {token: requestInit?.headers?.token || token} : {}),
     }
   })
 

--- a/src/helpers/api.js
+++ b/src/helpers/api.js
@@ -14,6 +14,14 @@ const contentTypeJSON = {
   'content-type': 'application/json; charset=utf-8'
 }
 
+const fetchWithToken = token => (requestInfo, requestInit = { headers: {}}) => fetch(requestInfo, {
+  ...requestInit,
+  headers: {
+    ...requestInit.headers,
+    token: requestInit?.headers?.token || token,
+  }
+})
+
 export const Api = ({
   token,
   onServerError,
@@ -25,13 +33,7 @@ export const Api = ({
 }) => {
   const { apiUrl, nodeUrl } = environmentToUrls(environment, network)
 
-  const authenticatedFetch = token !== undefined ? (requestInfo, requestInit = { headers: {}}) => fetch(requestInfo, {
-    ...requestInit,
-    headers: {
-      ...requestInit.headers,
-      token: requestInit?.headers?.token || token,
-    }
-  }) : fetch
+  const authenticatedFetch = token !== undefined ? fetchWithToken(token) : fetch
 
   const processParsedResponse = ({ url, options }) => ({ status, body, headers }) => {
     if (status === 200) {


### PR DESCRIPTION
- `token` is now not included in headers if undefined.
- `email` is taken from the user's input since it's no longer returned by the API in the unauthenticated version of the `GET /accounts/:id` endpoint, nor is it returned by `POST /login`.