### PR TITLE
refactor: new api client

### DIFF
--- a/src/apis/frost.js
+++ b/src/apis/frost.js
@@ -48,6 +48,3 @@ export const endpoints = {
 
 // const accountPoeChallengePost = (issuer) => apiPost(`accounts/${issuer}/poe-challenge`)
 // const accountVerify = (token) => apiFetch(`${apiUrl}/accounts/verify/${token}`, { headers: { token }})
-//
-// const workGetById = (id) => apiFetch(`${nodeUrl}/works/${id}`)
-// const worksGetByFilters = (filters = {}) => apiFetch(`${nodeUrl}/works?${filtersToQueryParams(filters)}`)

--- a/src/apis/frost.js
+++ b/src/apis/frost.js
@@ -17,7 +17,7 @@ export const FrostApi = (environment, token) => ApiClient({
   })
 })
 
-export const resources = {
+const resources = {
   accounts: {
     get: true,
     find: true,

--- a/src/apis/frost.js
+++ b/src/apis/frost.js
@@ -1,3 +1,4 @@
+import { withTotalCount } from 'helpers/array'
 import { assertEnvironment } from 'helpers/api'
 import { ApiClient } from 'helpers/ApiClient'
 
@@ -7,6 +8,13 @@ export const FrostApi = (environment, token) => ApiClient({
   headers: {
     token,
   },
+  afterResponse: ({ status, headers, body }) => ({
+    status,
+    headers,
+    body: Array.isArray(body)
+      ? withTotalCount(body, headers.get('X-TOTAL-COUNT'))
+      : body,
+  })
 })
 
 export const endpoints = {

--- a/src/apis/frost.js
+++ b/src/apis/frost.js
@@ -15,6 +15,8 @@ export const endpoints = {
     find: true,
     post: true,
     patch: true,
+// const accountPoeChallengePost = (issuer) => apiPost(`accounts/${issuer}/poe-challenge`)
+// const accountVerify = (token) => apiFetch(`${apiUrl}/accounts/verify/${token}`, { headers: { token }})
   },
   login: {
     post: true,
@@ -48,9 +50,6 @@ export const endpoints = {
     }
   },
 }
-
-// const accountPoeChallengePost = (issuer) => apiPost(`accounts/${issuer}/poe-challenge`)
-// const accountVerify = (token) => apiFetch(`${apiUrl}/accounts/verify/${token}`, { headers: { token }})
 
 const environmentToUrl = (environment) => {
   assertEnvironment(environment)

--- a/src/apis/frost.js
+++ b/src/apis/frost.js
@@ -4,7 +4,7 @@ import { withTotalCount } from 'helpers/array'
 import { assertEnvironment } from 'helpers/api'
 import { ApiClient } from 'helpers/ApiClient'
 
-export const FrostApi = (environment, token, afterResponse = identity) => ApiClient({
+export const FrostApi = ({ environment, token, afterResponse = identity }) => ApiClient({
   url: environmentToUrl(environment),
   resources,
   headers: {

--- a/src/apis/frost.js
+++ b/src/apis/frost.js
@@ -1,15 +1,17 @@
+import { identity, pipe } from 'ramda'
+
 import { withTotalCount } from 'helpers/array'
 import { assertEnvironment } from 'helpers/api'
 import { ApiClient } from 'helpers/ApiClient'
 
-export const FrostApi = (environment, token) => ApiClient({
+export const FrostApi = (environment, token, afterResponse = identity) => ApiClient({
   url: environmentToUrl(environment),
   resources,
   headers: {
     'content-type': 'application/json; charset=utf-8',
     token,
   },
-  afterResponse,
+  afterResponse: pipe(internalAfterResponse, afterResponse),
 })
 
 const resources = {
@@ -54,7 +56,7 @@ const resources = {
   },
 }
 
-const afterResponse = ({ status, headers, body }) => ({
+const internalAfterResponse = ({ status, headers, body }) => ({
   status,
   headers,
   body: Array.isArray(body)

--- a/src/apis/frost.js
+++ b/src/apis/frost.js
@@ -1,0 +1,69 @@
+export const FrostApi = (url, token) => ({
+  url,
+  endpoints,
+  headers: {
+    token,
+  },
+})
+
+export const endpoints = {
+  accounts: {
+    get: {
+      // `${apiUrl}/accounts/${issuer}`
+    },
+    find: {
+      // apiFetch(`${apiUrl}/accounts?${filtersToQueryParams(searchParams)}`)
+    },
+    post: {
+
+    },
+    patch: {
+      // apiPatch(`accounts/${issuer}`)
+    },
+  },
+  login: {
+    post: {
+
+    },
+  },
+  tokens: {
+    get: true,
+    post: true,
+    delete: true,
+  },
+  passwordReset: {
+    url: '/password/reset',
+    post: {
+
+    },
+  },
+  passwordChangeWithToken: {
+    url: '/password/change/token',
+    post: {
+
+    },
+  },
+  passwordChangeWithOld: {
+    url: '/password/change',
+    post: {
+
+    },
+  },
+  works: {
+    post: {
+      // uses different auth (ApiKey)
+    },
+  },
+  archives: {
+    post: {
+      // allow fetch to infer content-type
+      // uses different auth (ApiKey)
+    }
+  },
+}
+
+// const accountPoeChallengePost = (issuer) => apiPost(`accounts/${issuer}/poe-challenge`)
+// const accountVerify = (token) => apiFetch(`${apiUrl}/accounts/verify/${token}`, { headers: { token }})
+//
+// const workGetById = (id) => apiFetch(`${nodeUrl}/works/${id}`)
+// const worksGetByFilters = (filters = {}) => apiFetch(`${nodeUrl}/works?${filtersToQueryParams(filters)}`)

--- a/src/apis/frost.js
+++ b/src/apis/frost.js
@@ -6,6 +6,7 @@ export const FrostApi = (environment, token) => ApiClient({
   url: environmentToUrl(environment),
   resources,
   headers: {
+    'content-type': 'application/json; charset=utf-8',
     token,
   },
   afterResponse,

--- a/src/apis/frost.js
+++ b/src/apis/frost.js
@@ -8,23 +8,13 @@ export const FrostApi = (url, token) => ({
 
 export const endpoints = {
   accounts: {
-    get: {
-      // `${apiUrl}/accounts/${issuer}`
-    },
-    find: {
-      // apiFetch(`${apiUrl}/accounts?${filtersToQueryParams(searchParams)}`)
-    },
-    post: {
-
-    },
-    patch: {
-      // apiPatch(`accounts/${issuer}`)
-    },
+    get: true,
+    find: true,
+    post: true,
+    patch: true,
   },
   login: {
-    post: {
-
-    },
+    post: true,
   },
   tokens: {
     get: true,
@@ -33,21 +23,15 @@ export const endpoints = {
   },
   passwordReset: {
     url: '/password/reset',
-    post: {
-
-    },
+    post: true,
   },
   passwordChangeWithToken: {
     url: '/password/change/token',
-    post: {
-
-    },
+    post: true,
   },
   passwordChangeWithOld: {
     url: '/password/change',
-    post: {
-
-    },
+    post: true,
   },
   works: {
     post: {

--- a/src/apis/frost.js
+++ b/src/apis/frost.js
@@ -1,5 +1,8 @@
-export const FrostApi = (url, token) => ({
-  url,
+import { assertEnvironment } from 'helpers/api'
+import { ApiClient } from 'helpers/ApiClient'
+
+export const FrostApi = (environment, token) => ApiClient({
+  url: environmentToUrl(environment),
   endpoints,
   headers: {
     token,
@@ -48,3 +51,9 @@ export const endpoints = {
 
 // const accountPoeChallengePost = (issuer) => apiPost(`accounts/${issuer}/poe-challenge`)
 // const accountVerify = (token) => apiFetch(`${apiUrl}/accounts/verify/${token}`, { headers: { token }})
+
+const environmentToUrl = (environment) => {
+  assertEnvironment(environment)
+  const environmentPrefix = environment === 'production' ? '' : environment + '.'
+  return `https://api.${environmentPrefix}poetnetwork.net`
+}

--- a/src/apis/frost.js
+++ b/src/apis/frost.js
@@ -4,7 +4,7 @@ import { ApiClient } from 'helpers/ApiClient'
 
 export const FrostApi = (environment, token) => ApiClient({
   url: environmentToUrl(environment),
-  endpoints,
+  resources,
   headers: {
     token,
   },
@@ -17,7 +17,7 @@ export const FrostApi = (environment, token) => ApiClient({
   })
 })
 
-export const endpoints = {
+export const resources = {
   accounts: {
     get: true,
     find: true,

--- a/src/apis/frost.js
+++ b/src/apis/frost.js
@@ -8,13 +8,7 @@ export const FrostApi = (environment, token) => ApiClient({
   headers: {
     token,
   },
-  afterResponse: ({ status, headers, body }) => ({
-    status,
-    headers,
-    body: Array.isArray(body)
-      ? withTotalCount(body, headers.get('X-TOTAL-COUNT'))
-      : body,
-  })
+  afterResponse,
 })
 
 const resources = {
@@ -58,6 +52,14 @@ const resources = {
     }
   },
 }
+
+const afterResponse = ({ status, headers, body }) => ({
+  status,
+  headers,
+  body: Array.isArray(body)
+    ? withTotalCount(body, headers.get('X-TOTAL-COUNT'))
+    : body,
+})
 
 const environmentToUrl = (environment) => {
   assertEnvironment(environment)

--- a/src/apis/poetNode.js
+++ b/src/apis/poetNode.js
@@ -1,9 +1,9 @@
 export const PoetNodeApi = (url) => ({
   url,
-  endpoints,
+  resources,
 })
 
-const endpoints = {
+const resources = {
   works: {
     get: true,
     find: true,

--- a/src/apis/poetNode.js
+++ b/src/apis/poetNode.js
@@ -1,0 +1,11 @@
+export const PoetNodeApi = (url) => ({
+  url,
+  endpoints,
+})
+
+const endpoints = {
+  works: {
+    get: true,
+    find: true,
+  }
+}

--- a/src/apis/poetNode.js
+++ b/src/apis/poetNode.js
@@ -1,4 +1,6 @@
-export const PoetNodeApi = (url) => ({
+import { ApiClient } from 'helpers/ApiClient'
+
+export const PoetNodeApi = (url) => ApiClient({
   url,
   resources,
 })

--- a/src/components/pages/Login.jsx
+++ b/src/components/pages/Login.jsx
@@ -29,9 +29,9 @@ export const Login = () => {
   }, [loginResponse])
 
   useEffect(() => {
-    if (api?.token)
-      api.accountGet(loginResponse.issuer).then(setGetAccountResponse)
-  }, [api])
+    if (frostApi && account && loginResponse)
+      frostApi.accounts.get(loginResponse.issuer).then(setGetAccountResponse)
+  }, [frostApi])
 
   useEffect(() => {
     if (getAccountResponse)

--- a/src/components/pages/Login.jsx
+++ b/src/components/pages/Login.jsx
@@ -11,7 +11,7 @@ import { SessionContext } from 'providers/SessionProvider'
 import classNames from './Login.scss'
 
 export const Login = () => {
-  const [api, isBusy, useApi, environment, network] = useContext(ApiContext)
+  const [api, isBusy, useApi, environment, network, frostApi] = useContext(ApiContext)
   const [account, setAccount] = useContext(SessionContext)
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -20,7 +20,7 @@ export const Login = () => {
 
   const onSubmit = event => {
     event.preventDefault()
-    api.login({ email, password }).then(setLoginResponse)
+    frostApi.login({ email, password }).then(setLoginResponse)
   }
 
   useEffect(() => {

--- a/src/components/pages/Login.jsx
+++ b/src/components/pages/Login.jsx
@@ -20,7 +20,7 @@ export const Login = () => {
 
   const onSubmit = event => {
     event.preventDefault()
-    frostApi.login({ email, password }).then(setLoginResponse)
+    frostApi.login.post({ email, password }).then(setLoginResponse)
   }
 
   useEffect(() => {

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -24,55 +24,60 @@ const endpointOptionIsOperation = (operation) => operations.includes(operation)
 const filterOperations = ([operation]) => endpointOptionIsOperation(operation)
 
 const resourceDefinitionToFetchArguments = ({ url, method, headers }) => {
-  const map = {
-    get: id => ({
-      url: `${url}/${id}`,
-      init: {
-        method: 'get',
-        headers,
-      },
-    }),
-    find: searchParams => ({
-      url: `${url}?${filtersToQueryParams(searchParams)}`,
-      init: {
-        method: 'get',
-        headers,
-      },
-    }),
-    post: body => ({
-      url,
-      init: {
-        method: 'post',
-        body: JSON.stringify(body),
-        headers,
-      }
-    }),
-    put: (id, body) => ({
-      url: `${url}/${id}`,
-      init: {
-        method: 'put',
-        body: JSON.stringify(body),
-        headers,
-      }
-    }),
-    patch: (id, body) => ({
-      url: `${url}/${id}`,
-      init: {
-        method: 'patch',
-        body: JSON.stringify(body),
-        headers,
-      }
-    }),
-    delete: (id, body) => ({
-      url: `${url}/${id}`,
-      init: {
-        method: 'delete',
-        body: JSON.stringify(body),
-        headers,
-      }
-    }),
+  switch (method) {
+    case 'get':
+      return id => ({
+        url: `${url}/${id}`,
+        init: {
+          method,
+          headers,
+        },
+      })
+    case 'find':
+      return searchParams => ({
+        url: `${url}?${filtersToQueryParams(searchParams)}`,
+        init: {
+          method: 'get',
+          headers,
+        },
+      })
+    case 'post':
+      return body => ({
+        url,
+        init: {
+          method,
+          headers,
+          body: JSON.stringify(body),
+        }
+      })
+    case 'put':
+      return (id, body) => ({
+        url: `${url}/${id}`,
+        init: {
+          method,
+          headers,
+          body: JSON.stringify(body),
+        }
+      })
+    case 'patch':
+      return (id, body) => ({
+        url: `${url}/${id}`,
+        init: {
+          method,
+          headers,
+          body: JSON.stringify(body),
+        }
+      })
+    case 'delete':
+      return (id, body) => ({
+        url: `${url}/${id}`,
+        init: {
+          method,
+          headers,
+          body: JSON.stringify(body),
+        }
+      })
   }
-  return map[method]
 }
 
 // const usage =  async (apiClient) => {

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -5,13 +5,8 @@ export const ApiClient = ({
   url,
   headers,
   resources,
-  afterResponse,
+  afterResponse = _ => _,
 }) => {
-  const processParsedResponseWrapper = _ =>
-    afterResponse
-      ? afterResponse(_)
-      : _
-
   const takeBody = ({ body }) => body
 
   const apiInit = (init) => ({
@@ -32,7 +27,7 @@ export const ApiClient = ({
     const { url: resourceUrl, init } = getFetchArguments(...args)
     return fetch(url + resourceUrl, apiInit(init))
       .then(parseResponse)
-      .then(processParsedResponseWrapper)
+      .then(afterResponse)
       .then(takeBody)
   }
 

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -13,7 +13,7 @@ export const ApiClient = ({
   const pickBody = ({ body }) => body
 
   const resourceOperationToFetch = (resourceName, resource) => (method, options) => asyncPipe(
-    resourceDefinitionToFetchArguments({
+    operationToFetchArguments({
       url: url + (resource.url || '/' + resourceName),
       method,
       headers: { ...headers, ...resource.headers, ...options.headers },
@@ -41,7 +41,7 @@ const resourceOptionIsOperation = (operation) => operations.includes(operation)
 
 const operations = ['get', 'find', 'post', 'put', 'patch', 'delete']
 
-const resourceDefinitionToFetchArguments = ({ url, method, headers }) => {
+const operationToFetchArguments = ({ url, method, headers }) => {
   switch (method) {
     case 'get':
       return id => ({

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -1,37 +1,54 @@
 import { flattenArray } from './array'
 import { filtersToQueryParams } from './api'
+import {mapObjectValues} from './object'
 
-export const ApiClient = (api) => {
-  const headers = {
-    'content-type': 'application/json; charset=utf-8',
-    ...api.headers,
-  }
+// export const ApiClient = (api) => {
+//   const headers = {
+//     'content-type': 'application/json; charset=utf-8',
+//     ...api.headers,
+//   }
+//
+//   const resources = apiDefinitionToFlat(api.endpoints).map(resource => ({
+//     ...resource,
+//     url: api.url + resource.url,
+//     headers,
+//   }))
+//
+//   const apiClient = resources.map(resource => ({
+//     resource,
+//     fetchArguments: (...args) => {
+//       const fetchArguments = resourceDefinitionToFetchArguments(resource)(...args)
+//       return fetchArguments
+//     },
+//   })).reduce((acc, val) => ({
+//     ...acc,
+//     [val.resource.resource]: {
+//       ...acc[val.resource.resource],
+//       [val.resource.method]: (...args) => {
+//         const { url, init } = val.fetchArguments(...args)
+//         return fetch(url, init)
+//       },
+//     },
+//   }), {})
+//
+//   return apiClient
+// }
 
-  const resources = apiDefinitionToFlat(api.endpoints).map(resource => ({
-    ...resource,
-    url: api.url + resource.url,
-    headers,
-  }))
-
-  const apiClient = resources.map(resource => ({
+export const ApiClient = (api) => mapObjectValues(
+  api.endpoints,
+  (resourceName, resource) => mapObjectValues(
     resource,
-    fetchArguments: (...args) => {
-      const fetchArguments = resourceDefinitionToFetchArguments(resource)(...args)
-      return fetchArguments
-    },
-  })).reduce((acc, val) => ({
-    ...acc,
-    [val.resource.resource]: {
-      ...acc[val.resource.resource],
-      [val.resource.method]: (...args) => {
-        const { url, init } = val.fetchArguments(...args)
-        return fetch(url, init)
+    (method, options) => ({ // resourceDefinitionToFetchArguments
+      url: api.url + '/' + (resource.url || resourceName),
+      method,
+      // options,
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        ...api.headers,
       },
-    },
-  }), {})
-
-  return apiClient
-}
+    }),
+  )
+)
 
 const apiDefinitionToFlat = (resources) => {
   const apiClient = Object.entries(resources)
@@ -118,3 +135,4 @@ const resourceDefinitionToFetchArguments = ({ url: baseUrl, method, headers }) =
 //   const createdAccount = await apiClient.accounts.post({ email: 'email@domain.com' })
 //   const patchedAccount = await apiClient.accounts.patch('issuer', { poeAddress: 'poeAddress' })
 // }
+

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -45,12 +45,6 @@ export const ApiClient = ({
     resources,
     resourceToFetch,
   )
-
-  // return resources.mapEntries(
-  //   (resourceName, resource) => resource
-  //     .filterEntries(resourceEntryIsOperation)
-  //     .mapEntries(resourceOperationToFetch(resourceName, resource))
-  // )
 }
 
 const resourceEntryIsOperation = ([operation]) => resourceOptionIsOperation(operation)

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -1,12 +1,12 @@
 import { filtersToQueryParams } from './api'
 import { mapObjectEntries, filterObjectEntries } from './object'
 
-export const ApiClient = (api, processParsedResponse) => {
+export const ApiClient = (api) => {
   const fetchArguments = apiToFetchArguments(api)
 
   const processParsedResponseWrapper = _ => {
-    if (processParsedResponse)
-      return processParsedResponse(_)
+    if (api.afterResponse)
+      return api.afterResponse(_)
     return _.body
   }
 

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -12,14 +12,19 @@ export const ApiClient = ({
 }) => {
   const pickBody = ({ body }) => body
 
-  const bleh = (resourceName, resource, method, options) => ({
-    url: url + (resource.url || '/' + resourceName),
+  const bleh = (resource, method, options) => ({
     method,
     headers: { ...headers, ...resource.headers, ...options.headers },
   })
 
+  const makeUrl = (resourceName, resource) => ({ url: asd = '', init }) => ({
+    url: url + (resource.url || '/' + resourceName) + asd,
+    init,
+  })
+
   const resourceOperationToFetch = (resourceName, resource) => (method, options) => asyncPipe(
-    operationToFetchArguments(bleh(resourceName, resource, method, options)),
+    operationToFetchArguments(bleh(resource, method, options)),
+    makeUrl(resourceName, resource),
     unaryFetch,
     parseResponse,
     afterResponse,
@@ -47,7 +52,7 @@ const operationToFetchArguments = ({ url, method, headers }) => {
   switch (method) {
     case 'get':
       return id => ({
-        url: `${url}/${id}`,
+        url: `/${id}`,
         init: {
           method,
           headers,
@@ -55,7 +60,7 @@ const operationToFetchArguments = ({ url, method, headers }) => {
       })
     case 'find':
       return searchParams => ({
-        url: `${url}?${filtersToQueryParams(searchParams)}`,
+        url: `?${filtersToQueryParams(searchParams)}`,
         init: {
           method: 'get',
           headers,
@@ -63,7 +68,6 @@ const operationToFetchArguments = ({ url, method, headers }) => {
       })
     case 'post':
       return body => ({
-        url,
         init: {
           method,
           headers,
@@ -72,7 +76,7 @@ const operationToFetchArguments = ({ url, method, headers }) => {
       })
     case 'put':
       return (id, body) => ({
-        url: `${url}/${id}`,
+        url: `/${id}`,
         init: {
           method,
           headers,
@@ -81,7 +85,7 @@ const operationToFetchArguments = ({ url, method, headers }) => {
       })
     case 'patch':
       return (id, body) => ({
-        url: `${url}/${id}`,
+        url: `/${id}`,
         init: {
           method,
           headers,
@@ -90,7 +94,7 @@ const operationToFetchArguments = ({ url, method, headers }) => {
       })
     case 'delete':
       return (id, body) => ({
-        url: `${url}/${id}`,
+        url: `/${id}`,
         init: {
           method,
           headers,

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -1,10 +1,10 @@
 import { filtersToQueryParams } from './api'
-import { mapObjectEntries } from './object'
+import { mapObjectEntries, filterObjectEntries } from './object'
 
 export const ApiClient = (api) => mapObjectEntries(
   api.endpoints,
-  (resourceName, resource) => mapObjectEntries( // todo: filterObjectEntries(filterOperations)
-    resource,
+  (resourceName, resource) => mapObjectEntries(
+    filterObjectEntries(resource, filterOperations),
     (method, options) => resourceDefinitionToFetchArguments({
       url: api.url + '/' + (resource.url || resourceName),
       method,

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -19,12 +19,11 @@ export const ApiClient = ({
   })
 
   const resourceOperationToFetch = (resourceName, resource) => (method, options) => (...args) => {
-    const getFetchArguments = resourceDefinitionToFetchArguments({
+    const { url: resourceUrl, init } = resourceDefinitionToFetchArguments({
       url: resource.url || '/' + resourceName,
       method,
-      // options,
-    })
-    const { url: resourceUrl, init } = getFetchArguments(...args)
+      // headers: { ...resource.headers, ...options.headers },
+    })(...args)
     return fetch(url + resourceUrl, apiInit(init))
       .then(parseResponse)
       .then(afterResponse)

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -12,12 +12,14 @@ export const ApiClient = ({
 }) => {
   const pickBody = ({ body }) => body
 
+  const bleh = (resourceName, resource, method, options) => ({
+    url: url + (resource.url || '/' + resourceName),
+    method,
+    headers: { ...headers, ...resource.headers, ...options.headers },
+  })
+
   const resourceOperationToFetch = (resourceName, resource) => (method, options) => asyncPipe(
-    operationToFetchArguments({
-      url: url + (resource.url || '/' + resourceName),
-      method,
-      headers: { ...headers, ...resource.headers, ...options.headers },
-    }),
+    operationToFetchArguments(bleh(resourceName, resource, method, options)),
     unaryFetch,
     parseResponse,
     afterResponse,

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -7,8 +7,6 @@ export const ApiClient = ({
   resources,
   afterResponse,
 }) => {
-  const processedResources = resourcesToFetchArguments(resources)
-
   const processParsedResponseWrapper = _ =>
     afterResponse
       ? afterResponse(_)
@@ -26,10 +24,15 @@ export const ApiClient = ({
   })
 
   return mapObjectEntries(
-    processedResources,
+    resources,
     (resourceName, resource) => mapObjectEntries(
       filterObjectEntries(resource, filterOperations),
-      (method, getFetchArguments) => (...args) => {
+      (method, options) => (...args) => {
+        const getFetchArguments = resourceDefinitionToFetchArguments({
+          url: resource.url || '/' + resourceName,
+          method,
+          // options,
+        })
         const { url: resourceUrl, init } = getFetchArguments(...args)
         return fetch(url + resourceUrl, apiInit(init))
           .then(parseResponse)
@@ -39,18 +42,6 @@ export const ApiClient = ({
     )
   )
 }
-
-const resourcesToFetchArguments = (resources) => mapObjectEntries(
-  resources,
-  (resourceName, resource) => mapObjectEntries(
-    resource,
-    (method, options) => resourceDefinitionToFetchArguments({
-      url: resource.url || '/' + resourceName,
-      method,
-      // options,
-    }),
-  )
-)
 
 const filterOperations = ([operation]) => resourceOptionIsOperation(operation)
 

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -125,11 +125,3 @@ const parseResponse = async response => ({
   body: await parseResponseBody(response),
   headers: response.headers,
 })
-
-// const usage =  async (apiClient) => {
-//   const account = await apiClient.accounts.get('issuer')
-//   const accounts = await apiClient.accounts.find({ issuer: 'issuer' })
-//   const createdAccount = await apiClient.accounts.post({ email: 'email@domain.com' })
-//   const patchedAccount = await apiClient.accounts.patch('issuer', { poeAddress: 'poeAddress' })
-// }
-

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -12,24 +12,12 @@ export const ApiClient = ({
 }) => {
   const pickBody = ({ body }) => body
 
-  const apiInit = (init) => ({
-    ...init,
-    headers: {
-      'content-type': 'application/json; charset=utf-8',
-      ...init.headers,
-      ...headers,
-    }
-  })
-
-  const addApiFetchArguments = ({ url, init }) => ({ url, init: apiInit(init) })
-
   const resourceOperationToFetch = (resourceName, resource) => (method, options) => asyncPipe(
     resourceDefinitionToFetchArguments({
       url: url + (resource.url || '/' + resourceName),
       method,
-      // headers: { ...resource.headers, ...options.headers },
+      headers: { ...headers, ...resource.headers, ...options.headers },
     }),
-    addApiFetchArguments,
     unaryFetch,
     parseResponse,
     afterResponse,

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -21,11 +21,11 @@ export const ApiClient = ({
     }
   })
 
-  const addApiFetchArguments = ({ url: operationUrl, init }) => ({ url: url + operationUrl, init: apiInit(init) })
+  const addApiFetchArguments = ({ url, init }) => ({ url, init: apiInit(init) })
 
   const resourceOperationToFetch = (resourceName, resource) => (method, options) => asyncPipe(
     resourceDefinitionToFetchArguments({
-      url: resource.url || '/' + resourceName,
+      url: url + (resource.url || '/' + resourceName),
       method,
       // headers: { ...resource.headers, ...options.headers },
     }),

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -4,10 +4,10 @@ import { mapObjectEntries, filterObjectEntries } from './object'
 export const ApiClient = ({
   url,
   headers,
-  endpoints,
+  resources,
   afterResponse,
 }) => {
-  const resources = resourcesToFetchArguments(endpoints)
+  const processedResources = resourcesToFetchArguments(resources)
 
   const processParsedResponseWrapper = _ =>
     afterResponse
@@ -26,7 +26,7 @@ export const ApiClient = ({
   })
 
   return mapObjectEntries(
-    resources,
+    processedResources,
     (resourceName, resource) => mapObjectEntries(
       resource,
       (method, getFetchArguments) => (...args) => {
@@ -52,9 +52,9 @@ const resourcesToFetchArguments = (resources) => mapObjectEntries(
   )
 )
 
-const filterOperations = ([operation]) => endpointOptionIsOperation(operation)
+const filterOperations = ([operation]) => resourceOptionIsOperation(operation)
 
-const endpointOptionIsOperation = (operation) => operations.includes(operation)
+const resourceOptionIsOperation = (operation) => operations.includes(operation)
 
 const operations = ['get', 'find', 'post', 'put', 'patch', 'delete']
 

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -26,7 +26,7 @@ export const ApiClient = ({
   })
 
   const resourceOperationToFetch = (resourceName, resource) => (method, options) => asyncPipe(
-    operationToFetchArguments({ method }),
+    operationToFetchArguments(method),
     makeUrl(resourceName, resource),
     makeHeaders(resource, options),
     unaryFetch,
@@ -52,7 +52,7 @@ const resourceOptionIsOperation = (operation) => operations.includes(operation)
 
 const operations = ['get', 'find', 'post', 'put', 'patch', 'delete']
 
-const operationToFetchArguments = ({ method }) => {
+const operationToFetchArguments = (method) => {
   switch (method) {
     case 'get':
       return id => ({

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -11,21 +11,22 @@ export const ApiClient = (api) => {
 
   const takeBody = ({ body }) => body
 
+  const apiInit = (init) => ({
+    ...init,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      ...init.headers,
+      ...api.headers,
+    }
+  })
+
   return mapObjectEntries(
     resources,
     (resourceName, resource) => mapObjectEntries(
       resource,
       (method, getFetchArguments) => (...args) => {
         const { url, init } = getFetchArguments(...args)
-        const mergedInit = {
-          ...init,
-          headers: {
-            'content-type': 'application/json; charset=utf-8',
-            ...init.headers,
-            ...api.headers,
-          }
-        }
-        return fetch(api.url + url, mergedInit)
+        return fetch(api.url + url, apiInit(init))
           .then(parseResponse)
           .then(processParsedResponseWrapper)
           .then(takeBody)

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -12,7 +12,7 @@ export const ApiClient = ({
   resources,
   afterResponse = _ => _,
 }) => {
-  const takeBody = ({ body }) => body
+  const pickBody = ({ body }) => body
 
   const apiInit = (init) => ({
     ...init,
@@ -35,7 +35,7 @@ export const ApiClient = ({
     unaryFetch,
     parseResponse,
     afterResponse,
-    takeBody
+    pickBody
   )
 
   const resourceToFetch = (resourceName, resource) => mapObjectEntries(

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -6,7 +6,7 @@ export const ApiClient = (api) => mapObjectEntries(
   (resourceName, resource) => mapObjectEntries(
     filterObjectEntries(resource, filterOperations),
     (method, options) => resourceDefinitionToFetchArguments({
-      url: api.url + '/' + (resource.url || resourceName),
+      url: api.url + (resource.url || '/' + resourceName),
       method,
       // options,
       headers: {

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -4,11 +4,12 @@ import { mapObjectEntries, filterObjectEntries } from './object'
 export const ApiClient = (api) => {
   const fetchArguments = apiToFetchArguments(api)
 
-  const processParsedResponseWrapper = _ => {
-    if (api.afterResponse)
-      return api.afterResponse(_)
-    return _.body
-  }
+  const processParsedResponseWrapper = _ =>
+    api.afterResponse
+      ? api.afterResponse(_)
+      : _
+
+  const takeBody = ({ body }) => body
 
   return mapObjectEntries(
     fetchArguments,
@@ -19,6 +20,7 @@ export const ApiClient = (api) => {
         return fetch(url, init)
           .then(parseResponse)
           .then(processParsedResponseWrapper)
+          .then(takeBody)
       }
     )
   )

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -34,7 +34,7 @@ export const ApiClient = ({
   })
 
   const resourceOperationToFetch = (resourceName, resource) => (method, options) => asyncPipe(
-    operationToFetchArguments(method),
+    operationToFetchArguments[method],
     makeUrl(resourceName, resource),
     makeHeaders(resource, options),
     addMethod(method),
@@ -61,47 +61,39 @@ const resourceOptionIsOperation = (operation) => operations.includes(operation)
 
 const operations = ['get', 'find', 'post', 'put', 'patch', 'delete']
 
-const operationToFetchArguments = (method) => {
-  switch (method) {
-    case 'get':
-      return id => ({
-        url: `/${id}`,
-      })
-    case 'find':
-      return searchParams => ({
-        url: `?${filtersToQueryParams(searchParams)}`,
-        init: {
-          method: 'get',
-        },
-      })
-    case 'post':
-      return body => ({
-        init: {
-          body: JSON.stringify(body),
-        }
-      })
-    case 'put':
-      return (id, body) => ({
-        url: `/${id}`,
-        init: {
-          body: JSON.stringify(body),
-        }
-      })
-    case 'patch':
-      return (id, body) => ({
-        url: `/${id}`,
-        init: {
-          body: JSON.stringify(body),
-        }
-      })
-    case 'delete':
-      return (id, body) => ({
-        url: `/${id}`,
-        init: {
-          body: JSON.stringify(body),
-        }
-      })
-  }
+const operationToFetchArguments = {
+  'get': id => ({
+    url: `/${id}`,
+  }),
+  'find': searchParams => ({
+    url: `?${filtersToQueryParams(searchParams)}`,
+    init: {
+      method: 'get',
+    },
+  }),
+  'post': body => ({
+    init: {
+      body: JSON.stringify(body),
+    }
+  }),
+  'put': (id, body) => ({
+    url: `/${id}`,
+    init: {
+      body: JSON.stringify(body),
+    }
+  }),
+  'patch': (id, body) => ({
+    url: `/${id}`,
+    init: {
+      body: JSON.stringify(body),
+    }
+  }),
+  'delete': (id, body) => ({
+    url: `/${id}`,
+    init: {
+      body: JSON.stringify(body),
+    }
+  }),
 }
 
 const isJSON = response => response.headers.get('content-type').split(';')[0] === 'application/json'

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -1,3 +1,5 @@
+import { identity } from 'ramda'
+
 import { filtersToQueryParams } from './api'
 import { mapObjectEntries, filterObjectEntries } from './object'
 import { asyncPipe, unaryFetch } from './functional'
@@ -6,7 +8,7 @@ export const ApiClient = ({
   url,
   headers,
   resources,
-  afterResponse = _ => _,
+  afterResponse = identity,
 }) => {
   const pickBody = ({ body }) => body
 

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -12,19 +12,23 @@ export const ApiClient = ({
 }) => {
   const pickBody = ({ body }) => body
 
-  const bleh = (resource, method, options) => ({
-    method,
-    headers: { ...headers, ...resource.headers, ...options.headers },
-  })
-
   const makeUrl = (resourceName, resource) => ({ url: asd = '', init }) => ({
     url: url + (resource.url || '/' + resourceName) + asd,
     init,
   })
 
+  const makeHeaders = (resource, options) => ({ url, init }) => ({
+    url,
+    init: {
+      ...init,
+      headers: { ...headers, ...resource.headers, ...options.headers },
+    }
+  })
+
   const resourceOperationToFetch = (resourceName, resource) => (method, options) => asyncPipe(
-    operationToFetchArguments(bleh(resource, method, options)),
+    operationToFetchArguments({ method }),
     makeUrl(resourceName, resource),
+    makeHeaders(resource, options),
     unaryFetch,
     parseResponse,
     afterResponse,
@@ -48,14 +52,13 @@ const resourceOptionIsOperation = (operation) => operations.includes(operation)
 
 const operations = ['get', 'find', 'post', 'put', 'patch', 'delete']
 
-const operationToFetchArguments = ({ url, method, headers }) => {
+const operationToFetchArguments = ({ method }) => {
   switch (method) {
     case 'get':
       return id => ({
         url: `/${id}`,
         init: {
           method,
-          headers,
         },
       })
     case 'find':
@@ -63,14 +66,12 @@ const operationToFetchArguments = ({ url, method, headers }) => {
         url: `?${filtersToQueryParams(searchParams)}`,
         init: {
           method: 'get',
-          headers,
         },
       })
     case 'post':
       return body => ({
         init: {
           method,
-          headers,
           body: JSON.stringify(body),
         }
       })
@@ -79,7 +80,6 @@ const operationToFetchArguments = ({ url, method, headers }) => {
         url: `/${id}`,
         init: {
           method,
-          headers,
           body: JSON.stringify(body),
         }
       })
@@ -88,7 +88,6 @@ const operationToFetchArguments = ({ url, method, headers }) => {
         url: `/${id}`,
         init: {
           method,
-          headers,
           body: JSON.stringify(body),
         }
       })
@@ -97,7 +96,6 @@ const operationToFetchArguments = ({ url, method, headers }) => {
         url: `/${id}`,
         init: {
           method,
-          headers,
           body: JSON.stringify(body),
         }
       })

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -12,8 +12,8 @@ export const ApiClient = ({
 }) => {
   const pickBody = ({ body }) => body
 
-  const makeUrl = (resourceName, resource) => ({ url: asd = '', init }) => ({
-    url: url + (resource.url || '/' + resourceName) + asd,
+  const makeUrl = (resourceName, resource) => ({ url: operationUrl = '', init }) => ({
+    url: url + (resource.url || '/' + resourceName) + operationUrl,
     init,
   })
 

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -1,12 +1,17 @@
 import { filtersToQueryParams } from './api'
 import { mapObjectEntries, filterObjectEntries } from './object'
 
-export const ApiClient = (api) => {
-  const resources = resourcesToFetchArguments(api.endpoints)
+export const ApiClient = ({
+  url,
+  headers,
+  endpoints,
+  afterResponse,
+}) => {
+  const resources = resourcesToFetchArguments(endpoints)
 
   const processParsedResponseWrapper = _ =>
-    api.afterResponse
-      ? api.afterResponse(_)
+    afterResponse
+      ? afterResponse(_)
       : _
 
   const takeBody = ({ body }) => body
@@ -16,7 +21,7 @@ export const ApiClient = (api) => {
     headers: {
       'content-type': 'application/json; charset=utf-8',
       ...init.headers,
-      ...api.headers,
+      ...headers,
     }
   })
 
@@ -25,8 +30,8 @@ export const ApiClient = (api) => {
     (resourceName, resource) => mapObjectEntries(
       resource,
       (method, getFetchArguments) => (...args) => {
-        const { url, init } = getFetchArguments(...args)
-        return fetch(api.url + url, apiInit(init))
+        const { url: resourceUrl, init } = getFetchArguments(...args)
+        return fetch(url + resourceUrl, apiInit(init))
           .then(parseResponse)
           .then(processParsedResponseWrapper)
           .then(takeBody)

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -23,7 +23,10 @@ export const ApiClient = (api) => {
     ...acc,
     [val.resource.resource]: {
       ...acc[val.resource.resource],
-      [val.resource.method]: val.fetchArguments,
+      [val.resource.method]: (...args) => {
+        const { url, init } = val.fetchArguments(...args)
+        return fetch(url, init)
+      },
     },
   }), {})
 

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -25,10 +25,19 @@ export const ApiClient = ({
     }
   })
 
+  const addMethod = (method) => ({ url, init }) => ({
+    url,
+    init: {
+      method,
+      ...init,
+    }
+  })
+
   const resourceOperationToFetch = (resourceName, resource) => (method, options) => asyncPipe(
     operationToFetchArguments(method),
     makeUrl(resourceName, resource),
     makeHeaders(resource, options),
+    addMethod(method),
     unaryFetch,
     parseResponse,
     afterResponse,
@@ -57,9 +66,6 @@ const operationToFetchArguments = (method) => {
     case 'get':
       return id => ({
         url: `/${id}`,
-        init: {
-          method,
-        },
       })
     case 'find':
       return searchParams => ({
@@ -71,7 +77,6 @@ const operationToFetchArguments = (method) => {
     case 'post':
       return body => ({
         init: {
-          method,
           body: JSON.stringify(body),
         }
       })
@@ -79,7 +84,6 @@ const operationToFetchArguments = (method) => {
       return (id, body) => ({
         url: `/${id}`,
         init: {
-          method,
           body: JSON.stringify(body),
         }
       })
@@ -87,7 +91,6 @@ const operationToFetchArguments = (method) => {
       return (id, body) => ({
         url: `/${id}`,
         init: {
-          method,
           body: JSON.stringify(body),
         }
       })
@@ -95,7 +98,6 @@ const operationToFetchArguments = (method) => {
       return (id, body) => ({
         url: `/${id}`,
         init: {
-          method,
           body: JSON.stringify(body),
         }
       })

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -1,42 +1,9 @@
-import { flattenArray } from './array'
 import { filtersToQueryParams } from './api'
-import {mapObjectValues} from './object'
-
-// export const ApiClient = (api) => {
-//   const headers = {
-//     'content-type': 'application/json; charset=utf-8',
-//     ...api.headers,
-//   }
-//
-//   const resources = apiDefinitionToFlat(api.endpoints).map(resource => ({
-//     ...resource,
-//     url: api.url + resource.url,
-//     headers,
-//   }))
-//
-//   const apiClient = resources.map(resource => ({
-//     resource,
-//     fetchArguments: (...args) => {
-//       const fetchArguments = resourceDefinitionToFetchArguments(resource)(...args)
-//       return fetchArguments
-//     },
-//   })).reduce((acc, val) => ({
-//     ...acc,
-//     [val.resource.resource]: {
-//       ...acc[val.resource.resource],
-//       [val.resource.method]: (...args) => {
-//         const { url, init } = val.fetchArguments(...args)
-//         return fetch(url, init)
-//       },
-//     },
-//   }), {})
-//
-//   return apiClient
-// }
+import { mapObjectValues } from './object'
 
 export const ApiClient = (api) => mapObjectValues(
   api.endpoints,
-  (resourceName, resource) => mapObjectValues(
+  (resourceName, resource) => mapObjectValues( // todo: filterObjectEntries(filterOperations)
     resource,
     (method, options) => resourceDefinitionToFetchArguments({
       url: api.url + '/' + (resource.url || resourceName),
@@ -49,27 +16,6 @@ export const ApiClient = (api) => mapObjectValues(
     }),
   )
 )
-
-const apiDefinitionToFlat = (resources) => {
-  const apiClient = Object.entries(resources)
-    .map(([endpoint, endpointOptions]) => ({
-      endpoint,
-      endpointOptions,
-    }))
-    .map(({ endpoint, endpointOptions }) => (
-      Object
-        .entries(endpointOptions)
-        .filter(filterOperations)
-        .map(([ method, options ]) => ({ method, options }))
-        .map(({ method, options }) => ({
-          resource: endpoint,
-          url: endpointOptions.url || '/' + endpoint,
-          method,
-          options,
-        }))
-    ))
-  return flattenArray(apiClient)
-}
 
 const operations = ['get', 'find', 'post', 'put', 'patch', 'delete']
 

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -1,9 +1,9 @@
 import { filtersToQueryParams } from './api'
-import { mapObjectValues } from './object'
+import { mapObjectEntries } from './object'
 
-export const ApiClient = (api) => mapObjectValues(
+export const ApiClient = (api) => mapObjectEntries(
   api.endpoints,
-  (resourceName, resource) => mapObjectValues( // todo: filterObjectEntries(filterOperations)
+  (resourceName, resource) => mapObjectEntries( // todo: filterObjectEntries(filterOperations)
     resource,
     (method, options) => resourceDefinitionToFetchArguments({
       url: api.url + '/' + (resource.url || resourceName),

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -17,11 +17,11 @@ export const ApiClient = (api) => mapObjectEntries(
   )
 )
 
-const operations = ['get', 'find', 'post', 'put', 'patch', 'delete']
+const filterOperations = ([operation]) => endpointOptionIsOperation(operation)
 
 const endpointOptionIsOperation = (operation) => operations.includes(operation)
 
-const filterOperations = ([operation]) => endpointOptionIsOperation(operation)
+const operations = ['get', 'find', 'post', 'put', 'patch', 'delete']
 
 const resourceDefinitionToFetchArguments = ({ url, method, headers }) => {
   switch (method) {

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -2,7 +2,7 @@ import { filtersToQueryParams } from './api'
 import { mapObjectEntries, filterObjectEntries } from './object'
 
 export const ApiClient = (api) => {
-  const resources = resourcesToFetchArguments(api)
+  const resources = resourcesToFetchArguments(api.endpoints)
 
   const processParsedResponseWrapper = _ =>
     api.afterResponse

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -17,7 +17,7 @@ export const ApiClient = ({
     init,
   })
 
-  const makeHeaders = (resource, options) => ({ url, init }) => ({
+  const addHeaders = (resource, options) => ({ url, init }) => ({
     url,
     init: {
       ...init,
@@ -36,7 +36,7 @@ export const ApiClient = ({
   const resourceOperationToFetch = (resourceName, resource) => (method, options) => asyncPipe(
     operationToFetchArguments[method],
     makeUrl(resourceName, resource),
-    makeHeaders(resource, options),
+    addHeaders(resource, options),
     addMethod(method),
     unaryFetch,
     parseResponse,

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -1,0 +1,40 @@
+import { flattenArray } from './array'
+
+export const ApiClient = api => {
+  const apiClient = apiDefinitionToFlat(api)
+  return apiClient
+}
+
+const apiDefinitionToFlat = (api) => {
+  const apiClient = Object.entries(api.endpoints)
+    .map(([endpoint, endpointOptions]) => ({
+      endpoint,
+      endpointOptions,
+    }))
+    .map(({ endpoint, endpointOptions }) => (
+      Object
+        .entries(endpointOptions)
+        .filter(filterOperations)
+        .map(([ method, options ]) => ({ method, options }))
+        .map(({ method, options }) => ({
+          resource: endpoint,
+          url: endpointOptions.url || '/' + endpoint,
+          method,
+          options,
+        }))
+    ))
+  return flattenArray(apiClient)
+}
+
+const operations = ['get', 'find', 'post', 'put', 'patch', 'delete']
+
+const endpointOptionIsOperation = (operation) => operations.includes(operation)
+
+const filterOperations = ([operation, operationConfiguration]) => endpointOptionIsOperation(operation)
+
+// const usage =  async (apiClient) => {
+//   const account = await apiClient.accounts.get('issuer')
+//   const accounts = await apiClient.accounts.find({ issuer: 'issuer' })
+//   const createdAccount = await apiClient.accounts.post({ email: 'email@domain.com' })
+//   const patchedAccount = await apiClient.accounts.patch('issuer', { poeAddress: 'poeAddress' })
+// }

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -1,10 +1,6 @@
 import { filtersToQueryParams } from './api'
 import { mapObjectEntries, filterObjectEntries } from './object'
-
-export const asyncPipe = (...fns) =>
-  (v) => fns.reduce(async (a, c) => c(await a), Promise.resolve(v))
-
-const unaryFetch = ({ url, init}) => fetch(url, init)
+import { asyncPipe, unaryFetch } from './functional'
 
 export const ApiClient = ({
   url,

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -1,7 +1,22 @@
 import { filtersToQueryParams } from './api'
 import { mapObjectEntries, filterObjectEntries } from './object'
 
-export const ApiClient = (api) => mapObjectEntries(
+export const ApiClient = (api) => {
+  const fetchArguments = apiToFetchArguments(api)
+
+  return mapObjectEntries(
+    fetchArguments,
+    (resourceName, resource) => mapObjectEntries(
+      resource,
+      (method, getFetchArguments) => (...args) => {
+        const { url, init } = getFetchArguments(...args)
+        return fetch(url, init)
+      }
+    )
+  )
+}
+
+const apiToFetchArguments = (api) => mapObjectEntries(
   api.endpoints,
   (resourceName, resource) => mapObjectEntries(
     filterObjectEntries(resource, filterOperations),

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -2,19 +2,16 @@ import { flattenArray } from './array'
 import { filtersToQueryParams } from './api'
 
 export const ApiClient = (api) => {
-  const resources = apiDefinitionToFlat(api.endpoints).map(resource => ({
-    ...resource,
-    url: api.url + resource.url,
-  }))
-
   const headers = {
     'content-type': 'application/json; charset=utf-8',
     ...api.headers,
   }
 
-  // const resourceDefinitionToFunction = ({ baseUrl, method }) => {
-  //   const {}
-  // }
+  const resources = apiDefinitionToFlat(api.endpoints).map(resource => ({
+    ...resource,
+    url: api.url + resource.url,
+    headers,
+  }))
 
   const apiClient = resources.map(resource => ({
     resource,
@@ -55,46 +52,52 @@ const endpointOptionIsOperation = (operation) => operations.includes(operation)
 
 const filterOperations = ([operation]) => endpointOptionIsOperation(operation)
 
-const resourceDefinitionToFetchArguments = ({ url: baseUrl, method }) => {
+const resourceDefinitionToFetchArguments = ({ url: baseUrl, method, headers }) => {
   const map = {
     get: id => ({
       url: `${baseUrl}/${id}`,
       init: {
         method: 'get',
+        headers,
       },
     }),
     find: searchParams => ({
       url: `${baseUrl}?${filtersToQueryParams(searchParams)}`,
       init: {
         method: 'get',
+        headers,
       },
     }),
     post: body => ({
       url: baseUrl,
       init: {
         method: 'post',
-        body: JSON.stringify(body)
+        body: JSON.stringify(body),
+        headers,
       }
     }),
     put: (id, body) => ({
       url: `${baseUrl}/${id}`,
       init: {
         method: 'put',
-        body: JSON.stringify(body)
+        body: JSON.stringify(body),
+        headers,
       }
     }),
     patch: (id, body) => ({
       url: `${baseUrl}/${id}`,
       init: {
         method: 'patch',
-        body: JSON.stringify(body)
+        body: JSON.stringify(body),
+        headers,
       }
     }),
     delete: (id, body) => ({
       url: `${baseUrl}/${id}`,
       init: {
         method: 'delete',
-        body: JSON.stringify(body)
+        body: JSON.stringify(body),
+        headers,
       }
     }),
   }

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -28,7 +28,7 @@ export const ApiClient = ({
   return mapObjectEntries(
     processedResources,
     (resourceName, resource) => mapObjectEntries(
-      resource,
+      filterObjectEntries(resource, filterOperations),
       (method, getFetchArguments) => (...args) => {
         const { url: resourceUrl, init } = getFetchArguments(...args)
         return fetch(url + resourceUrl, apiInit(init))
@@ -43,7 +43,7 @@ export const ApiClient = ({
 const resourcesToFetchArguments = (resources) => mapObjectEntries(
   resources,
   (resourceName, resource) => mapObjectEntries(
-    filterObjectEntries(resource, filterOperations),
+    resource,
     (method, options) => resourceDefinitionToFetchArguments({
       url: resource.url || '/' + resourceName,
       method,

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -38,7 +38,7 @@ export const ApiClient = (api) => mapObjectValues(
   api.endpoints,
   (resourceName, resource) => mapObjectValues(
     resource,
-    (method, options) => ({ // resourceDefinitionToFetchArguments
+    (method, options) => resourceDefinitionToFetchArguments({
       url: api.url + '/' + (resource.url || resourceName),
       method,
       // options,

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -19,12 +19,12 @@ export const ApiClient = ({
   })
 
   const resourceOperationToFetch = (resourceName, resource) => (method, options) => (...args) => {
-    const { url: resourceUrl, init } = resourceDefinitionToFetchArguments({
+    const { url: operationUrl, init } = resourceDefinitionToFetchArguments({
       url: resource.url || '/' + resourceName,
       method,
       // headers: { ...resource.headers, ...options.headers },
     })(...args)
-    return fetch(url + resourceUrl, apiInit(init))
+    return fetch(url + operationUrl, apiInit(init))
       .then(parseResponse)
       .then(afterResponse)
       .then(takeBody)

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -17,10 +17,15 @@ export const ApiClient = (api) => {
     resource,
     fetchArguments: (...args) => {
       const fetchArguments = resourceDefinitionToFetchArguments(resource)(...args)
-      // return fetch(fetchArguments.url, fetchArguments.init)
       return fetchArguments
     },
-  }))
+  })).reduce((acc, val) => ({
+    ...acc,
+    [val.resource.resource]: {
+      ...acc[val.resource.resource],
+      [val.resource.method]: val.fetchArguments,
+    },
+  }), {})
 
   return apiClient
 }

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -23,24 +23,24 @@ const endpointOptionIsOperation = (operation) => operations.includes(operation)
 
 const filterOperations = ([operation]) => endpointOptionIsOperation(operation)
 
-const resourceDefinitionToFetchArguments = ({ url: baseUrl, method, headers }) => {
+const resourceDefinitionToFetchArguments = ({ url, method, headers }) => {
   const map = {
     get: id => ({
-      url: `${baseUrl}/${id}`,
+      url: `${url}/${id}`,
       init: {
         method: 'get',
         headers,
       },
     }),
     find: searchParams => ({
-      url: `${baseUrl}?${filtersToQueryParams(searchParams)}`,
+      url: `${url}?${filtersToQueryParams(searchParams)}`,
       init: {
         method: 'get',
         headers,
       },
     }),
     post: body => ({
-      url: baseUrl,
+      url,
       init: {
         method: 'post',
         body: JSON.stringify(body),
@@ -48,7 +48,7 @@ const resourceDefinitionToFetchArguments = ({ url: baseUrl, method, headers }) =
       }
     }),
     put: (id, body) => ({
-      url: `${baseUrl}/${id}`,
+      url: `${url}/${id}`,
       init: {
         method: 'put',
         body: JSON.stringify(body),
@@ -56,7 +56,7 @@ const resourceDefinitionToFetchArguments = ({ url: baseUrl, method, headers }) =
       }
     }),
     patch: (id, body) => ({
-      url: `${baseUrl}/${id}`,
+      url: `${url}/${id}`,
       init: {
         method: 'patch',
         body: JSON.stringify(body),
@@ -64,7 +64,7 @@ const resourceDefinitionToFetchArguments = ({ url: baseUrl, method, headers }) =
       }
     }),
     delete: (id, body) => ({
-      url: `${baseUrl}/${id}`,
+      url: `${url}/${id}`,
       init: {
         method: 'delete',
         body: JSON.stringify(body),

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -34,8 +34,8 @@ export const ApiClient = (api) => {
   )
 }
 
-const apiToFetchArguments = (api) => mapObjectEntries(
-  api.endpoints,
+const apiToFetchArguments = (endpoints) => mapObjectEntries(
+  endpoints,
   (resourceName, resource) => mapObjectEntries(
     filterObjectEntries(resource, filterOperations),
     (method, options) => resourceDefinitionToFetchArguments({

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -1,12 +1,35 @@
 import { flattenArray } from './array'
+import { filtersToQueryParams } from './api'
 
-export const ApiClient = api => {
-  const apiClient = apiDefinitionToFlat(api)
+export const ApiClient = (api) => {
+  const resources = apiDefinitionToFlat(api.endpoints).map(resource => ({
+    ...resource,
+    url: api.url + resource.url,
+  }))
+
+  const headers = {
+    'content-type': 'application/json; charset=utf-8',
+    ...api.headers,
+  }
+
+  // const resourceDefinitionToFunction = ({ baseUrl, method }) => {
+  //   const {}
+  // }
+
+  const apiClient = resources.map(resource => ({
+    resource,
+    fetchArguments: (...args) => {
+      const fetchArguments = resourceDefinitionToFetchArguments(resource)(...args)
+      // return fetch(fetchArguments.url, fetchArguments.init)
+      return fetchArguments
+    },
+  }))
+
   return apiClient
 }
 
-const apiDefinitionToFlat = (api) => {
-  const apiClient = Object.entries(api.endpoints)
+const apiDefinitionToFlat = (resources) => {
+  const apiClient = Object.entries(resources)
     .map(([endpoint, endpointOptions]) => ({
       endpoint,
       endpointOptions,
@@ -30,7 +53,53 @@ const operations = ['get', 'find', 'post', 'put', 'patch', 'delete']
 
 const endpointOptionIsOperation = (operation) => operations.includes(operation)
 
-const filterOperations = ([operation, operationConfiguration]) => endpointOptionIsOperation(operation)
+const filterOperations = ([operation]) => endpointOptionIsOperation(operation)
+
+const resourceDefinitionToFetchArguments = ({ url: baseUrl, method }) => {
+  const map = {
+    get: id => ({
+      url: `${baseUrl}/${id}`,
+      init: {
+        method: 'get',
+      },
+    }),
+    find: searchParams => ({
+      url: `${baseUrl}?${filtersToQueryParams(searchParams)}`,
+      init: {
+        method: 'get',
+      },
+    }),
+    post: body => ({
+      url: baseUrl,
+      init: {
+        method: 'post',
+        body: JSON.stringify(body)
+      }
+    }),
+    put: (id, body) => ({
+      url: `${baseUrl}/${id}`,
+      init: {
+        method: 'put',
+        body: JSON.stringify(body)
+      }
+    }),
+    patch: (id, body) => ({
+      url: `${baseUrl}/${id}`,
+      init: {
+        method: 'patch',
+        body: JSON.stringify(body)
+      }
+    }),
+    delete: (id, body) => ({
+      url: `${baseUrl}/${id}`,
+      init: {
+        method: 'delete',
+        body: JSON.stringify(body)
+      }
+    }),
+  }
+  return map[method]
+}
 
 // const usage =  async (apiClient) => {
 //   const account = await apiClient.accounts.get('issuer')

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -17,7 +17,15 @@ export const ApiClient = (api) => {
       resource,
       (method, getFetchArguments) => (...args) => {
         const { url, init } = getFetchArguments(...args)
-        return fetch(url, init)
+        const mergedInit = {
+          ...init,
+          headers: {
+            'content-type': 'application/json; charset=utf-8',
+            ...init.headers,
+            ...api.headers,
+          }
+        }
+        return fetch(api.url + url, mergedInit)
           .then(parseResponse)
           .then(processParsedResponseWrapper)
           .then(takeBody)
@@ -31,13 +39,9 @@ const apiToFetchArguments = (api) => mapObjectEntries(
   (resourceName, resource) => mapObjectEntries(
     filterObjectEntries(resource, filterOperations),
     (method, options) => resourceDefinitionToFetchArguments({
-      url: api.url + (resource.url || '/' + resourceName),
+      url: resource.url || '/' + resourceName,
       method,
       // options,
-      headers: {
-        'content-type': 'application/json; charset=utf-8',
-        ...api.headers,
-      },
     }),
   )
 )

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -2,7 +2,7 @@ import { filtersToQueryParams } from './api'
 import { mapObjectEntries, filterObjectEntries } from './object'
 
 export const ApiClient = (api) => {
-  const fetchArguments = apiToFetchArguments(api)
+  const resources = resourcesToFetchArguments(api)
 
   const processParsedResponseWrapper = _ =>
     api.afterResponse
@@ -12,7 +12,7 @@ export const ApiClient = (api) => {
   const takeBody = ({ body }) => body
 
   return mapObjectEntries(
-    fetchArguments,
+    resources,
     (resourceName, resource) => mapObjectEntries(
       resource,
       (method, getFetchArguments) => (...args) => {
@@ -34,8 +34,8 @@ export const ApiClient = (api) => {
   )
 }
 
-const apiToFetchArguments = (endpoints) => mapObjectEntries(
-  endpoints,
+const resourcesToFetchArguments = (resources) => mapObjectEntries(
+  resources,
   (resourceName, resource) => mapObjectEntries(
     filterObjectEntries(resource, filterOperations),
     (method, options) => resourceDefinitionToFetchArguments({

--- a/src/helpers/api.js
+++ b/src/helpers/api.js
@@ -112,7 +112,7 @@ export const Api = ({
 
 }
 
-const filtersToQueryParams = (filters) => Object.entries(filters).map(([key, value]) => `${key}=${value}`).join('&')
+export const filtersToQueryParams = (filters) => Object.entries(filters).map(([key, value]) => `${key}=${value}`).join('&')
 
 const environmentToUrls = (environment, network) => {
   assertEnvironment(environment)

--- a/src/helpers/array.js
+++ b/src/helpers/array.js
@@ -6,10 +6,10 @@ export const withTotalCount = (array, totalCount) => {
 
 export const ofNumbers = (length, base = 0) => Array(length).fill(undefined).map((e, i) => i + base)
 
-export const flattenArray = (arr1) =>
-  arr1.reduce((acc, val) =>
+export const flattenArray = (array) =>
+  array.reduce((acc, val) =>
       Array.isArray(val)
-        ? acc.concat(flattenArray(val))
-        : acc.concat(val),
+        ? [...acc, ...flattenArray(val)]
+        : [...acc, val],
     [],
   )

--- a/src/helpers/array.js
+++ b/src/helpers/array.js
@@ -5,11 +5,3 @@ export const withTotalCount = (array, totalCount) => {
 }
 
 export const ofNumbers = (length, base = 0) => Array(length).fill(undefined).map((e, i) => i + base)
-
-export const flattenArray = (array) =>
-  array.reduce((acc, val) =>
-      Array.isArray(val)
-        ? [...acc, ...flattenArray(val)]
-        : [...acc, val],
-    [],
-  )

--- a/src/helpers/array.js
+++ b/src/helpers/array.js
@@ -5,3 +5,11 @@ export const withTotalCount = (array, totalCount) => {
 }
 
 export const ofNumbers = (length, base = 0) => Array(length).fill(undefined).map((e, i) => i + base)
+
+export const flattenArray = (arr1) =>
+  arr1.reduce((acc, val) =>
+      Array.isArray(val)
+        ? acc.concat(flattenArray(val))
+        : acc.concat(val),
+    [],
+  )

--- a/src/helpers/functional.js
+++ b/src/helpers/functional.js
@@ -1,0 +1,4 @@
+export const asyncPipe = (...fns) =>
+  (v) => fns.reduce(async (a, c) => c(await a), Promise.resolve(v))
+
+export const unaryFetch = ({ url, init}) => fetch(url, init)

--- a/src/helpers/object.js
+++ b/src/helpers/object.js
@@ -1,2 +1,2 @@
-export const mapObjectValues = (o, f) =>
+export const mapObjectEntries = (o, f) =>
   Object.fromEntries(Object.entries(o).map(([key, value]) => [key, f(key, value)]))

--- a/src/helpers/object.js
+++ b/src/helpers/object.js
@@ -1,0 +1,2 @@
+export const mapObjectValues = (o, f) =>
+  Object.fromEntries(Object.entries(o).map(([key, value]) => [key, f(key, value)]))

--- a/src/helpers/object.js
+++ b/src/helpers/object.js
@@ -1,2 +1,5 @@
 export const mapObjectEntries = (o, f) =>
   Object.fromEntries(Object.entries(o).map(([key, value]) => [key, f(key, value)]))
+
+export const filterObjectEntries = (o, f) =>
+  Object.fromEntries(Object.entries(o).filter(f))

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -13,6 +13,6 @@ const reactRoot = document.getElementById('react-root');
 
 render(<App/>, reactRoot)
 
-const apiClient = ApiClient(FrostApi('https://api.qa.poetnetwork.net', ''))
+const apiClient = ApiClient(FrostApi('https://api.poetnetwork.net', ''))
 
 window.apiClient = apiClient

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,9 +2,6 @@ import * as React from 'react'
 import { render} from 'react-dom'
 import 'react-toastify/dist/ReactToastify.css'
 
-import { ApiClient } from 'helpers/ApiClient'
-import { FrostApi } from 'apis/frost'
-
 import './index.scss'
 
 import { App } from 'components/App'
@@ -12,7 +9,3 @@ import { App } from 'components/App'
 const reactRoot = document.getElementById('react-root');
 
 render(<App/>, reactRoot)
-
-const apiClient = ApiClient(FrostApi('https://api.poetnetwork.net', ''))
-
-window.apiClient = apiClient

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,6 +2,9 @@ import * as React from 'react'
 import { render} from 'react-dom'
 import 'react-toastify/dist/ReactToastify.css'
 
+import { ApiClient } from 'src/helpers/ApiClient'
+import { FrostApi } from 'apis/frost'
+
 import './index.scss'
 
 import { App } from 'components/App'
@@ -9,3 +12,5 @@ import { App } from 'components/App'
 const reactRoot = document.getElementById('react-root');
 
 render(<App/>, reactRoot)
+
+console.log(ApiClient(FrostApi('', '')))

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { render} from 'react-dom'
 import 'react-toastify/dist/ReactToastify.css'
 
-import { ApiClient } from 'src/helpers/ApiClient'
+import { ApiClient } from 'helpers/ApiClient'
 import { FrostApi } from 'apis/frost'
 
 import './index.scss'

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -13,4 +13,6 @@ const reactRoot = document.getElementById('react-root');
 
 render(<App/>, reactRoot)
 
-console.log(ApiClient(FrostApi('', '')))
+const apiClient = ApiClient(FrostApi('https://api.qa.poetnetwork.net', ''))
+
+window.apiClient = apiClient

--- a/src/providers/ApiProvider.jsx
+++ b/src/providers/ApiProvider.jsx
@@ -61,6 +61,10 @@ export const ApiProvider = props => {
     return response
   }
 
+  useEffect(() => {
+    window.frostApi = frostApi
+  }, [frostApi])
+
   return (
     <ApiContext.Provider value={[api, isBusy, useApi, environment, network, frostApi]}>
       { props.children }

--- a/src/providers/ApiProvider.jsx
+++ b/src/providers/ApiProvider.jsx
@@ -52,6 +52,10 @@ export const ApiProvider = props => {
     setFrostApi(FrostApi({
       environment,
       token: account?.token,
+      afterResponse: _ => {
+        toast.error(_.body)
+        return _
+      }
     }))
   }, [account, environment, network])
 

--- a/src/providers/ApiProvider.jsx
+++ b/src/providers/ApiProvider.jsx
@@ -53,7 +53,10 @@ export const ApiProvider = props => {
       environment,
       token: account?.token,
       afterResponse: _ => {
-        toast.error(_.body)
+        if (_.status !== 200) {
+          toast.error(_.body)
+          return null
+        }
         return _
       }
     }))

--- a/src/providers/ApiProvider.jsx
+++ b/src/providers/ApiProvider.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, createContext, useContext } from 'react'
 import { toast } from 'react-toastify'
 
+import { FrostApi } from 'apis/frost'
 import { Api } from 'helpers/api'
 
 import { SessionContext } from './SessionProvider'
@@ -13,6 +14,7 @@ export const ApiProvider = props => {
   const [environment, network] = useContext(ApiEnvironmentContext)
   const [api, setApi] = useState(null)
   const [isBusy, setIsBusy] = useState(false)
+  const [frostApi, setFrostApi] = useState(false)
 
   const clearAccount = () => setAccount(null)
 
@@ -47,6 +49,7 @@ export const ApiProvider = props => {
       environment,
       network,
     }))
+    setFrostApi(FrostApi(environment, account?.token))
   }, [account, environment, network])
 
   const useApi = (endpoint, ...args) => {
@@ -59,7 +62,7 @@ export const ApiProvider = props => {
   }
 
   return (
-    <ApiContext.Provider value={[api, isBusy, useApi, environment, network]}>
+    <ApiContext.Provider value={[api, isBusy, useApi, environment, network, frostApi]}>
       { props.children }
     </ApiContext.Provider>
   )

--- a/src/providers/ApiProvider.jsx
+++ b/src/providers/ApiProvider.jsx
@@ -49,7 +49,10 @@ export const ApiProvider = props => {
       environment,
       network,
     }))
-    setFrostApi(FrostApi(environment, account?.token))
+    setFrostApi(FrostApi({
+      environment,
+      token: account?.token,
+    }))
   }, [account, environment, network])
 
   const useApi = (endpoint, ...args) => {


### PR DESCRIPTION
New version of ApiClient. Generates an usable ApiClient out of a JSON ApiDefinition.

Login.jsx was updated to use this new API, but every other component is still using the old version of the API. The two coexist.

It uses [Object.fromEntries](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries) which [doesn't have a ton of support yet](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries#Browser_compatibility). May replace with Ramda's [mapObjIndexed](https://ramdajs.com/docs/#mapObjIndexed) altogether in the future.