### PR TITLE
fix: claim graph archive images

### DIFF
--- a/src/images/text-document-green.svg
+++ b/src/images/text-document-green.svg
@@ -1,18 +1,90 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="18px" height="22px" viewBox="0 0 18 22" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 57.1 (83088) - https://sketch.com -->
-    <title>file</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Work-Explorer" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="content" transform="translate(-856.000000, -430.000000)">
-            <g id="file" transform="translate(856.000000, 430.000000)">
-                <polygon id="Path-2" fill="#43B980" points="1.25 1 12.2424367 1 16.25 5.13439466 16.25 22 1.25 22"></polygon>
-                <path d="M17.2488875,4.45281729 C17.247382,4.32064516 17.1946885,4.19113709 17.0945708,4.09394159 L13.0311914,0.150863576 C13.0310142,0.150691701 13.0308814,0.150648732 13.0307043,0.150519825 C12.9347489,0.0574922998 12.8021738,0 12.6558275,0 L1.36754558,0 C0.751296991,0 0.25,0.4864072 0.25,1.08440446 L0.25,20.9155955 C0.25,21.5135498 0.751252711,22 1.3675013,22 L16.1324933,22 C16.7486976,22 17.25,21.5135928 17.25,20.9155955 L17.25,4.45814543 C17.25,4.4562548 17.2490647,4.45466495 17.2488875,4.45281729 Z M13.1866594,1.75875734 L15.4376029,3.94303504 L13.2425411,3.94303504 C13.2117663,3.94303504 13.1866594,3.91867172 13.1866594,3.88880838 L13.1866594,1.75875734 Z M16.1884192,20.9156385 C16.1884192,20.9455018 16.1633123,20.9698222 16.1325375,20.9698222 L1.36754558,20.9698222 C1.33677079,20.9698222 1.31170815,20.9455018 1.31170815,20.9156385 L1.31170815,1.08440446 C1.31170815,1.05454112 1.33677079,1.03022076 1.36754558,1.03022076 L12.1249955,1.03022076 L12.1249955,3.88880838 C12.1249955,4.48676267 12.6263368,4.97329878 13.2425854,4.97329878 L16.1884192,4.97329878 L16.1884192,20.9156385 L16.1884192,20.9156385 Z" id="Shape" fill="#000000" fill-rule="nonzero"></path>
-                <path d="M12.742401,7 L3.7576413,7 C3.47731219,7 3.25,7.22384885 3.25,7.5 C3.25,7.77610944 3.47731219,8 3.7576413,8 L12.7423587,8 C13.0226878,8 13.25,7.77610944 13.25,7.5 C13.25,7.22384885 13.0226878,7 12.742401,7 Z" id="Path" fill="#000000" fill-rule="nonzero"></path>
-                <path d="M12.742401,10 L3.7576413,10 C3.47731219,10 3.25,10.2238906 3.25,10.5 C3.25,10.7761094 3.47731219,11 3.7576413,11 L12.7423587,11 C13.0226878,11 13.25,10.7761094 13.25,10.5 C13.25,10.2238906 13.0226878,10 12.742401,10 Z" id="Path" fill="#000000" fill-rule="nonzero"></path>
-                <path d="M12.742401,13 L3.7576413,13 C3.47731219,13 3.25,13.2238906 3.25,13.5 C3.25,13.7761512 3.47731219,14 3.7576413,14 L12.7423587,14 C13.0226878,14 13.25,13.7761512 13.25,13.5 C13.25,13.2239323 13.0226878,13 12.742401,13 Z" id="Path" fill="#000000" fill-rule="nonzero"></path>
-                <path d="M8.69697995,16 L3.80302005,16 C3.49763194,16 3.25,16.2238906 3.25,16.5 C3.25,16.7761512 3.49763194,17 3.80302005,17 L8.69697995,17 C9.00236806,17 9.25,16.7761512 9.25,16.5 C9.25,16.2238488 9.00236806,16 8.69697995,16 Z" id="Path" fill="#000000" fill-rule="nonzero"></path>
-            </g>
-        </g>
-    </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="18px"
+   height="22px"
+   viewBox="0 0 18 22"
+   version="1.1"
+   id="svg18"
+   sodipodi:docname="text-document-green.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <metadata
+     id="metadata24">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs22" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="986"
+     inkscape:window-height="717"
+     id="namedview20"
+     showgrid="false"
+     inkscape:zoom="10.727273"
+     inkscape:cx="-3.7711864"
+     inkscape:cy="10.813559"
+     inkscape:window-x="2262"
+     inkscape:window-y="203"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="content" />
+  <!-- Generator: Sketch 57.1 (83088) - https://sketch.com -->
+  <title
+     id="title2">file</title>
+  <desc
+     id="desc4">Created with Sketch.</desc>
+  <g
+     style="fill:none;fill-rule:evenodd;stroke:none;stroke-width:1"
+     transform="translate(-855.90678,-429.90678)"
+     id="content">
+    <polygon
+       id="Path-2"
+       points="1.25,22 1.25,1 12.242437,1 16.25,5.1343947 16.25,22 "
+       style="fill:#43b980"
+       transform="matrix(1.003348,0,0,1.0404514,856.08903,429.11007)" />
+    <path
+       d="m 873.34211,434.45282 c -0.002,-0.13217 -0.0542,-0.26168 -0.15432,-0.35888 l -4.06338,-3.94308 c -1.8e-4,-1.7e-4 -3.1e-4,-2.1e-4 -4.9e-4,-3.4e-4 -0.096,-0.093 -0.22853,-0.15052 -0.37487,-0.15052 h -11.28828 c -0.61625,0 -1.11755,0.48641 -1.11755,1.0844 v 19.83119 c 0,0.59796 0.50125,1.08441 1.1175,1.08441 h 14.76499 c 0.61621,0 1.11751,-0.48641 1.11751,-1.08441 v -16.45744 c 0,-0.002 -9.4e-4,-0.003 -0.001,-0.005 z m -4.06223,-2.69406 2.25094,2.18427 h -2.19506 c -0.0308,0 -0.0559,-0.0244 -0.0559,-0.0542 z m 3.00176,19.15688 c 0,0.0299 -0.0251,0.0542 -0.0559,0.0542 h -14.76499 c -0.0308,0 -0.0558,-0.0243 -0.0558,-0.0542 V 431.0844 c 0,-0.0299 0.0251,-0.0542 0.0558,-0.0542 h 10.75745 v 2.85859 c 0,0.59795 0.50134,1.08449 1.11758,1.08449 h 2.94584 z"
+       id="Shape"
+       inkscape:connector-curvature="0"
+       style="fill:#000000;fill-rule:nonzero" />
+    <path
+       d="m 868.83562,437 h -8.98476 c -0.28033,0 -0.50764,0.22385 -0.50764,0.5 0,0.27611 0.22731,0.5 0.50764,0.5 h 8.98472 c 0.28033,0 0.50764,-0.22389 0.50764,-0.5 0,-0.27615 -0.22731,-0.5 -0.5076,-0.5 z"
+       id="Path"
+       inkscape:connector-curvature="0"
+       style="fill:#000000;fill-rule:nonzero" />
+    <path
+       d="m 868.83562,440 h -8.98476 c -0.28033,0 -0.50764,0.22389 -0.50764,0.5 0,0.27611 0.22731,0.5 0.50764,0.5 h 8.98472 c 0.28033,0 0.50764,-0.22389 0.50764,-0.5 0,-0.27611 -0.22731,-0.5 -0.5076,-0.5 z"
+       id="path9"
+       inkscape:connector-curvature="0"
+       style="fill:#000000;fill-rule:nonzero" />
+    <path
+       d="m 868.83562,443 h -8.98476 c -0.28033,0 -0.50764,0.22389 -0.50764,0.5 0,0.27615 0.22731,0.5 0.50764,0.5 h 8.98472 c 0.28033,0 0.50764,-0.22385 0.50764,-0.5 0,-0.27607 -0.22731,-0.5 -0.5076,-0.5 z"
+       id="path11"
+       inkscape:connector-curvature="0"
+       style="fill:#000000;fill-rule:nonzero" />
+    <path
+       d="m 864.7902,446 h -4.89396 c -0.30539,0 -0.55302,0.22389 -0.55302,0.5 0,0.27615 0.24763,0.5 0.55302,0.5 h 4.89396 c 0.30539,0 0.55302,-0.22385 0.55302,-0.5 0,-0.27615 -0.24763,-0.5 -0.55302,-0.5 z"
+       id="path13"
+       inkscape:connector-curvature="0"
+       style="fill:#000000;fill-rule:nonzero" />
+  </g>
 </svg>

--- a/src/images/text-document-white.svg
+++ b/src/images/text-document-white.svg
@@ -1,49 +1,90 @@
-<?xml version="1.0" encoding="iso-8859-1"?>
-<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="470.586px" height="470.586px" viewBox="0 0 470.586 470.586" style="enable-background:new 0 0 470.586 470.586;"
-	 xml:space="preserve">
-<g>
-	<path d="M327.081,0H90.234C74.331,0,61.381,12.959,61.381,28.859v412.863c0,15.924,12.95,28.863,28.853,28.863H380.35
-		c15.917,0,28.855-12.939,28.855-28.863V89.234L327.081,0z M333.891,43.184l35.996,39.121h-35.996V43.184z M384.972,441.723
-		c0,2.542-2.081,4.629-4.635,4.629H90.234c-2.55,0-4.619-2.087-4.619-4.629V28.859c0-2.548,2.069-4.613,4.619-4.613h219.411v70.181
-		c0,6.682,5.443,12.099,12.129,12.099h63.198V441.723z M128.364,128.89H334.15c5.013,0,9.079,4.066,9.079,9.079
-		c0,5.013-4.066,9.079-9.079,9.079H128.364c-5.012,0-9.079-4.066-9.079-9.079C119.285,132.957,123.352,128.89,128.364,128.89z
-		 M343.229,198.98c0,5.012-4.066,9.079-9.079,9.079H128.364c-5.012,0-9.079-4.066-9.079-9.079s4.067-9.079,9.079-9.079H334.15
-		C339.163,189.901,343.229,193.968,343.229,198.98z M343.229,257.993c0,5.013-4.066,9.079-9.079,9.079H128.364
-		c-5.012,0-9.079-4.066-9.079-9.079s4.067-9.079,9.079-9.079H334.15C339.163,248.914,343.229,252.98,343.229,257.993z
-		 M343.229,318.011c0,5.013-4.066,9.079-9.079,9.079H128.364c-5.012,0-9.079-4.066-9.079-9.079s4.067-9.079,9.079-9.079H334.15
-		C339.163,308.932,343.229,312.998,343.229,318.011z"/>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
-<g>
-</g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="18px"
+   height="22px"
+   viewBox="0 0 18 22"
+   version="1.1"
+   id="svg18"
+   sodipodi:docname="text-document-green.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <metadata
+     id="metadata24">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs22" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="986"
+     inkscape:window-height="717"
+     id="namedview20"
+     showgrid="false"
+     inkscape:zoom="10.727273"
+     inkscape:cx="-3.7711864"
+     inkscape:cy="10.813559"
+     inkscape:window-x="2262"
+     inkscape:window-y="203"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="content" />
+  <!-- Generator: Sketch 57.1 (83088) - https://sketch.com -->
+  <title
+     id="title2">file</title>
+  <desc
+     id="desc4">Created with Sketch.</desc>
+  <g
+     style="fill:none;fill-rule:evenodd;stroke:none;stroke-width:1"
+     transform="translate(-855.90678,-429.90678)"
+     id="content">
+    <polygon
+       id="Path-2"
+       points="1.25,22 1.25,1 12.242437,1 16.25,5.1343947 16.25,22 "
+       style="fill:#fff"
+       transform="matrix(1.003348,0,0,1.0404514,856.08903,429.11007)" />
+    <path
+       d="m 873.34211,434.45282 c -0.002,-0.13217 -0.0542,-0.26168 -0.15432,-0.35888 l -4.06338,-3.94308 c -1.8e-4,-1.7e-4 -3.1e-4,-2.1e-4 -4.9e-4,-3.4e-4 -0.096,-0.093 -0.22853,-0.15052 -0.37487,-0.15052 h -11.28828 c -0.61625,0 -1.11755,0.48641 -1.11755,1.0844 v 19.83119 c 0,0.59796 0.50125,1.08441 1.1175,1.08441 h 14.76499 c 0.61621,0 1.11751,-0.48641 1.11751,-1.08441 v -16.45744 c 0,-0.002 -9.4e-4,-0.003 -0.001,-0.005 z m -4.06223,-2.69406 2.25094,2.18427 h -2.19506 c -0.0308,0 -0.0559,-0.0244 -0.0559,-0.0542 z m 3.00176,19.15688 c 0,0.0299 -0.0251,0.0542 -0.0559,0.0542 h -14.76499 c -0.0308,0 -0.0558,-0.0243 -0.0558,-0.0542 V 431.0844 c 0,-0.0299 0.0251,-0.0542 0.0558,-0.0542 h 10.75745 v 2.85859 c 0,0.59795 0.50134,1.08449 1.11758,1.08449 h 2.94584 z"
+       id="Shape"
+       inkscape:connector-curvature="0"
+       style="fill:#000000;fill-rule:nonzero" />
+    <path
+       d="m 868.83562,437 h -8.98476 c -0.28033,0 -0.50764,0.22385 -0.50764,0.5 0,0.27611 0.22731,0.5 0.50764,0.5 h 8.98472 c 0.28033,0 0.50764,-0.22389 0.50764,-0.5 0,-0.27615 -0.22731,-0.5 -0.5076,-0.5 z"
+       id="Path"
+       inkscape:connector-curvature="0"
+       style="fill:#000000;fill-rule:nonzero" />
+    <path
+       d="m 868.83562,440 h -8.98476 c -0.28033,0 -0.50764,0.22389 -0.50764,0.5 0,0.27611 0.22731,0.5 0.50764,0.5 h 8.98472 c 0.28033,0 0.50764,-0.22389 0.50764,-0.5 0,-0.27611 -0.22731,-0.5 -0.5076,-0.5 z"
+       id="path9"
+       inkscape:connector-curvature="0"
+       style="fill:#000000;fill-rule:nonzero" />
+    <path
+       d="m 868.83562,443 h -8.98476 c -0.28033,0 -0.50764,0.22389 -0.50764,0.5 0,0.27615 0.22731,0.5 0.50764,0.5 h 8.98472 c 0.28033,0 0.50764,-0.22385 0.50764,-0.5 0,-0.27607 -0.22731,-0.5 -0.5076,-0.5 z"
+       id="path11"
+       inkscape:connector-curvature="0"
+       style="fill:#000000;fill-rule:nonzero" />
+    <path
+       d="m 864.7902,446 h -4.89396 c -0.30539,0 -0.55302,0.22389 -0.55302,0.5 0,0.27615 0.24763,0.5 0.55302,0.5 h 4.89396 c 0.30539,0 0.55302,-0.22385 0.55302,-0.5 0,-0.27615 -0.24763,-0.5 -0.55302,-0.5 z"
+       id="path13"
+       inkscape:connector-curvature="0"
+       style="fill:#000000;fill-rule:nonzero" />
+  </g>
 </svg>


### PR DESCRIPTION
- Green version: background wasn't correctly aligned, there was a blank/transparent area close to the top-right fold.
- White version: was too different from green version, made the selection awkward. Changed for the green white with a changed background color.

Credit goes to the love of my life, Marcia, taking care of Po.et behind the scenes :heart: 